### PR TITLE
Add Apple Pay JS blog post

### DIFF
--- a/source/2016-10-10-apple-pay-js.md
+++ b/source/2016-10-10-apple-pay-js.md
@@ -1,0 +1,13 @@
+---
+title: Apple Pay JS
+date: 2016-10-10
+tags: apple pay,js,javascript
+layout: bloglayout
+description: "Integrating Apple Pay JS"
+---
+
+I've been working on an integration of the new [Apple Pay JS](https://developer.apple.com/reference/applepayjs) SDK over the last few months. If you'd like to read about it, check out my post over on the [Just Eat Technology blog](https://tech.just-eat.com/2016/10/10/bringing-apple-pay-to-the-web/).
+
+READMORE
+
+It's been my first time integrating an Apple API and also the first non-hobby ASP.NET Core application I've worked on, and has been really interesting to work with - even if at times a little frustrating!


### PR DESCRIPTION
Add blog post linking to the Just Eat Technology [blog post](https://tech.just-eat.com/2016/10/10/bringing-apple-pay-to-the-web/).