### PR TITLE
Improve SEO description for Apple Pay

### DIFF
--- a/source/2016-10-10-apple-pay-js.md
+++ b/source/2016-10-10-apple-pay-js.md
@@ -3,7 +3,7 @@ title: Apple Pay JS
 date: 2016-10-10
 tags: apple pay,js,javascript
 layout: bloglayout
-description: "Integrating Apple Pay JS"
+description: "Information about how to integrate Apple Pay JS into an ASP.NET core website to accept Apple Pay payments."
 ---
 
 I've been working on an integration of the new [Apple Pay JS](https://developer.apple.com/reference/applepayjs) SDK over the last few months. If you'd like to read about it, check out my post over on the [Just Eat Technology blog](https://tech.just-eat.com/2016/10/10/bringing-apple-pay-to-the-web/).


### PR DESCRIPTION
Improve the SEO description for the Apple Pay post by making it longer.