### PR TITLE
Update AWS Lambda to node.js 10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ deploy:
     handler_name: "handler"
     module_name: "cloudfront-folders"
     timeout: 1,
-    runtime: "nodejs8.10"
+    runtime: "nodejs10.x"
     zip: "cloudfront-folders.js"
     publish: true
     on:
@@ -49,7 +49,7 @@ deploy:
     handler_name: "handler"
     module_name: "cloudfront-headers"
     timeout: 1,
-    runtime: "nodejs8.10"
+    runtime: "nodejs10.x"
     zip: "cloudfront-headers.js"
     publish: true
     on:


### PR DESCRIPTION
Update the AWS Lambda runtime for CloudFront@Edge to use node.js 10.x as 8.10 is being EOL'd.