### PR TITLE
Create CloudFront invalidation on deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,11 @@ python:
 rvm:
   - 2.2
 
-install:
-  - pip install awscli
-
 script:
   - git rev-parse HEAD > version.txt
   - git rev-parse --abbrev-ref HEAD > branch.txt
   - bundle exec middleman build
+  - pip install awscli
 
 deploy:
   - provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,14 @@ branches:
     - main
     - deploy
 
+python:
+  - 3.5
+
 rvm:
- - 2.2
+  - 2.2
+
+install:
+  - pip install awscli
 
 script:
   - git rev-parse HEAD > version.txt
@@ -56,3 +62,7 @@ deploy:
     publish: true
     on:
       branch: deploy
+
+after_deploy:
+  - aws configure set preview.cloudfront true
+  - test $TRAVIS_BRANCH = "deploy" && aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/*"


### PR DESCRIPTION
When the site is deployed from Travis, create a CloudFront invalidation so the updated content propagates as quickly as possible.