### PR TITLE
Clarify ICU requirement for native AoT in AWS Lambda

### DIFF
--- a/source/2023-11-29-native-aot-make-dotnet-lambda-go-brr.md
+++ b/source/2023-11-29-native-aot-make-dotnet-lambda-go-brr.md
@@ -55,7 +55,9 @@ For now I've [removed the polymorphism][remove-polymorphism], and I just created
 
 ### Using Invariant Globalization
 
-Another constraint of native AoT is that if you use globalisation features, say for `DateTime` formatting, you also need to include the [ICU libraries via a NuGet package][icu-nuget] and enable [App-local ICU][app-local-icu]. The downside of this is that it adds a lot of size to the published application - in my case, it doubled the size of the published artifacts for native AoT. Taking a look around in my code, I wasn't really actually using any features that needed culture-specific formatting support, so I was able to remove App-local ICU and use [invariant globalization][invariant-globalization] instead (`InvariantGlobalization=true`).
+Another constraint of native AoT is that if you use globalisation features, say for `DateTime` formatting, you also need to include the [ICU libraries via a NuGet package][icu-nuget] and enable [App-local ICU][app-local-icu]. This is because the `provided.al2023` custom runtime based on [Amazon Linux 2023][al-2023] does not include the ICU libraries by default.
+
+The downside of adding this is that it adds a lot of size to the published application - in my case, it doubled the size of the published artifacts for native AoT. Taking a look around in my code, I wasn't really actually using any features that needed culture-specific formatting support, so I was able to remove App-local ICU and use [invariant globalization][invariant-globalization] instead (`InvariantGlobalization=true`).
 
 ### Switch from Graviton (arm64) to x86_64
 
@@ -239,6 +241,7 @@ I hope that in the .NET 9 timeframe ASP.NET Core gets further support for native
 
 I hope that you've found this blog post interesting, and it helps you migrate some of your workloads to benefit fom native AoT and the improved performance it can bring to your applications. 🚀🔥
 
+[al-2023]: https://aws.amazon.com/about-aws/whats-new/2023/11/aws-lambda-amazon-linux-2023/ "AWS Lambda adds support for Amazon Linux 2023"
 [alexa-dotnet]: https://github.com/timheuer/alexa-skills-dotnet "Alexa Skills SDK for .NET on GitHub"
 [alexa-dotnet-262]: https://github.com/timheuer/alexa-skills-dotnet/issues/262 "AoT Support?"
 [alexa-dotnet-nuget]: https://www.nuget.org/packages/Alexa.NET "Alexa.NET"

--- a/source/2023-11-29-native-aot-make-dotnet-lambda-go-brr.md
+++ b/source/2023-11-29-native-aot-make-dotnet-lambda-go-brr.md
@@ -225,6 +225,10 @@ I've now removed the Dockerfile and the changes to the GitHub Actions workflow, 
 
 All-in-all it was a fun learning experience converting my first .NET application to use native AoT. I learned about some of the limitations of native AoT, and in many cases how to covercome them. The net result of the changes are that my Lambda function is now faster, smaller, and cheaper to run that ever before - thanks .NET team!
 
+I think this image of the _Duration minimum_ metric from CloudWatch for the Lambda function over the last 2 weeks says it all. Spot when the changes were deployed... 🚀
+
+<img class="img-fluid mx-auto d-block" src="https://cdn.martincostello.com/blog_aot-lambda-cloudwatch-metrics.png" alt="An AWS CloudWatch graph of the Duration minimum metric with a pronounced decrease and consistency of the Duration in milliseconds of the Lambda function invocations since 27th November" title="An AWS CloudWatch graph of the Duration minimum metric with a pronounced decrease and consistency of the Duration in milliseconds of the Lambda function invocations since 27th November">
+
 To summarise, the net effect of converting my Alexa skill's Lambda function to use native AoT are:
 
 - **Faster**: The Lambda function is now faster to start and respond to requests, with the cold-start time **reduced by 84%** and the billed duration **reduced by 88%**. 🏎️


### PR DESCRIPTION
- Clarify that the App-local ICU libraries are needed due to the `provided.al2023` runtime.
- Add graph of the Duration minimum metric for the last two weeks.
