### PR TITLE
Fix feed validation warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,11 @@ jobs:
       with:
         ruby-version: 3.3
 
+    - name: Update file timestamps
+      shell: bash
+      run: |
+        git ls-files | xargs -I{} git log -1 --date=format:%Y%m%d%H%M.%S --format='touch -t %ad "{}"' "{}" | $SHELL
+
     - name: Build blog
       shell: pwsh
       run: |

--- a/source/feed.xml.builder
+++ b/source/feed.xml.builder
@@ -6,7 +6,7 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom", "xml:lang" => "en-GB" do
   xml.id URI.join(site_url, blog.options.prefix.to_s)
   xml.link "href" => URI.join(site_url, blog.options.prefix.to_s)
   xml.link "href" => URI.join(site_url, current_page.path), "rel" => "self"
-  xml.rights "&copy; " + config[:blog_author] + " 2014-" + Time.now.utc.strftime("%Y")
+  xml.rights "&copy; " + config[:blog_author] + " 2014-" + Time.now.utc.strftime("%Y"), "type" => "html"
   xml.updated(blog.articles.first.date.to_time.iso8601) unless blog.articles.empty?
   xml.author do
     xml.name config[:blog_author]


### PR DESCRIPTION
- Add `type="html"` to the `<rights>` tag.
- Update file timestamps to use for `<updated>` tags.

Found via [W3C Feed Validation Service](https://validator.w3.org/feed/).