### PR TITLE
Use lint-actions-powershell

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,9 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        filter: 'tree:0'
+        show-progress: false
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
@@ -58,12 +61,15 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        filter: 'tree:0'
+        show-progress: false
 
     - name: Add actionlint problem matcher
       run: echo "::add-matcher::.github/actionlint-matcher.json"
 
     - name: Lint workflows
-      uses: docker://rhysd/actionlint@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 # v1.7.7
+      uses: docker://rhysd/actionlint:1.7.7
       with:
         args: -color
 
@@ -73,6 +79,15 @@ jobs:
         config: '.markdownlint.json'
         globs: |
           **/*.md
+
+    - name: Lint PowerShell in workflows
+      uses: martincostello/lint-actions-powershell@v1
+      with:
+        treat-warnings-as-errors: true
+
+    - name: Lint PowerShell scripts
+      shell: pwsh
+      run: Invoke-ScriptAnalyzer -Path . -Recurse -IncludeDefaultRules -ReportSummary -Severity @('Error','Warning') -EnableExit
 
   deploy:
     if: github.event.repository.fork == false && github.ref_name == 'deploy'

--- a/build.ps1
+++ b/build.ps1
@@ -13,7 +13,7 @@ git rev-parse --abbrev-ref HEAD > branch.txt
 bundler exec middleman build
 
 if ($LASTEXITCODE -ne 0) {
-    Write-Host "middleman build failed with exit code $LASTEXITCODE"
+    throw "middleman build failed with exit code $LASTEXITCODE"
 }
 
 if ($Serve) {


### PR DESCRIPTION
- Use martincostello/lint-actions-powershell to lint PowerShell code embedded in GitHub Actions workflow files.
- Add filter and hide progress when checking out code.
