### PR TITLE
Remove ruby-version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,6 @@ jobs:
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@a4effe49ee8ee5b8b5091268c473a4628afb5651 # v1.245.0
-      with:
-        ruby-version: 3.3
 
     - name: Update file timestamps
       shell: bash


### PR DESCRIPTION
Input is redundant when there's a `.ruby-version` file.
