### PR TITLE
Update platforms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,8 @@ gem 'terser', '~> 1.2.6'
 # For feed.xml.builder
 gem "builder", "~> 3.3.0"
 
-gem "tzinfo-data", "~> 1.2025.0", platforms: [:mswin, :mingw, :jruby, :x64_mingw]
-gem 'wdm', '~> 0.2.0', platforms: [:mswin, :mingw, :x64_mingw]
+gem "tzinfo-data", "~> 1.2025.0", platforms: [:windows]
+gem 'wdm', '~> 0.2.0', platforms: [:windows]
 
 gem "rack", "~> 3.1.16"
 gem "redcarpet", "~> 3.6.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    autoprefixer-rails (10.4.16.0)
+    autoprefixer-rails (10.4.21.0)
       execjs (~> 2)
     base64 (0.3.0)
     benchmark (0.4.1)
@@ -39,8 +39,14 @@ GEM
     execjs (2.10.0)
     fast_blank (1.0.1)
     fastimage (2.4.0)
-    ffi (1.17.2-x64-mingw-ucrt)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86_64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
     haml (6.3.0)
       temple (>= 0.8.2)
       thor
@@ -110,9 +116,21 @@ GEM
       middleman-core (>= 3.2)
       rouge (~> 3.2)
     minitest (5.25.5)
-    nokogiri (1.18.9-x64-mingw-ucrt)
+    nokogiri (1.18.9-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.9-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.9-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.9-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.9-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.9-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.9-x86_64-linux-musl)
       racc (~> 1.4)
     padrino-helpers (0.15.3)
       i18n (>= 0.6.7, < 2)
@@ -138,7 +156,7 @@ GEM
       ffi (~> 1.9)
     securerandom (0.4.1)
     servolux (0.13.0)
-    temple (0.10.3)
+    temple (0.10.4)
     terser (1.2.6)
       execjs (>= 0.3.0, < 3)
     thor (1.4.0)
@@ -147,17 +165,20 @@ GEM
       parslet (>= 1.8.0, < 3.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2025.2)
-      tzinfo (>= 1.0.0)
     uglifier (4.2.1)
       execjs (>= 0.3.0, < 3)
     uri (1.0.3)
-    wdm (0.2.0)
     webrick (1.9.1)
 
 PLATFORMS
-  x64-mingw-ucrt
-  x86_64-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   builder (~> 3.3.0)
@@ -177,4 +198,4 @@ DEPENDENCIES
   wdm (~> 0.2.0)
 
 BUNDLED WITH
-   2.7.0
+   2.7.1


### PR DESCRIPTION
Fix deprecation warning by using `windows`.
