### PR TITLE
Add image shortcode

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -5,12 +5,6 @@
       "a",
       "blockquote",
       "br",
-      "code",
-      "hr",
-      "img",
-      "p",
-      "pre",
-      "s",
       "script",
       "sup"
     ]

--- a/assets/scripts/site.js
+++ b/assets/scripts/site.js
@@ -21,7 +21,9 @@ window.addEventListener('load', async () => {
   if ('serviceWorker' in navigator) {
     try {
       const version = window.siteParameters?.version || '';
-      await navigator.serviceWorker.register('/service-worker.js?' + new URLSearchParams({ v: version }));
+      await navigator.serviceWorker.register(
+        '/service-worker.js?' + new URLSearchParams({ v: version })
+      );
     } catch (e) {
       console.error('Failed to register Service Worker: ', e);
     }

--- a/blog.spec.js
+++ b/blog.spec.js
@@ -42,7 +42,7 @@ test('archive links are valid', async ({ page }) => {
 });
 
 test('page images are valid', async ({ page }) => {
-  test.setTimeout(90_000);
+  test.setTimeout(120_000);
 
   await page.goto('/archive/');
 

--- a/blog.spec.js
+++ b/blog.spec.js
@@ -24,7 +24,7 @@ test('archive links are valid', async ({ page }) => {
 
   await expect(page).toHaveTitle(/Archive/);
 
-  const archiveLinks = await page.locator('a.archive-link');
+  const archiveLinks = page.locator('a.archive-link');
   await expect(archiveLinks).not.toHaveCount(0);
 
   const articles = [];
@@ -46,7 +46,7 @@ test('page images are valid', async ({ page }) => {
 
   await page.goto('/archive/');
 
-  const archiveLinks = await page.locator('a.archive-link');
+  const archiveLinks = page.locator('a.archive-link');
   await expect(archiveLinks).not.toHaveCount(0);
 
   const pageUrls = ['/', '/about-me/', '/archive/'];
@@ -59,7 +59,7 @@ test('page images are valid', async ({ page }) => {
     await page.goto(url);
     await page.waitForLoadState('networkidle');
 
-    const images = await page.locator('img');
+    const images = page.locator('img');
 
     for (const image of await images.elementHandles()) {
       const src = await image.getAttribute('src');
@@ -72,7 +72,7 @@ test('page images are valid', async ({ page }) => {
       }).toPass();
     }
 
-    const metaImage = await page.locator('meta[property="og:image"]');
+    const metaImage = page.locator('meta[property="og:image"]');
     if (metaImage) {
       await expect(async () => {
         const src = await metaImage.getAttribute('content');

--- a/content/posts/aspnet-core-21-supercharging-our-applications.md
+++ b/content/posts/aspnet-core-21-supercharging-our-applications.md
@@ -21,10 +21,7 @@ some great performance improvements – in some cases **improving average respon
 
 ## Background
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_aspnet-core-releases.png"
-     alt="ASP.NET Core release timeline"
-     title="ASP.NET Core release timeline">
+{{< cdn-image path="aspnet-core-releases.png" title="ASP.NET Core release timeline" >}}
 
 .NET Core 1.0 was released almost 2 years ago now, [in June 2016][dotnet-core-10], and we’ve been using it
 in some form or another at Just Eat ever since. Early adoption was rather limited amongst our teams, mainly
@@ -52,10 +49,7 @@ run on .NET Framework 4.6.x.
 
 A simple illustration of how these applications fit together in our architecture is shown below.
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_aws-network.png"
-     alt="Application architecture"
-     title="Application architecture">
+{{< cdn-image path="aws-network.png" title="Application architecture" >}}
 
 From Previews 1 and 2 to Release Candidate 1, we experimented with various new features and capabilities, as
 well as finding a few [bugs][bugs], [feature gaps][feature-gaps] and other changes along the way.
@@ -104,49 +98,31 @@ CPU statistics are collected separately on our AWS EC2 instances and also pushed
 
 ### API
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_api-response-times.png"
-     alt="Response times from the API between 16:30 and 22:30 on 10/06/18 with a -7 day timeshift."
-     title="Response times from the API between 16:30 and 22:30 on 10/06/18 with a -7 day timeshift.">
+{{< cdn-image path="api-response-times.png" title="Response times from the API between 16:30 and 22:30 on 10/06/18 with a -7 day timeshift." >}}
 
 The API averaged `107ms` per HTTP GET compared to `141ms` (**approximately a 24% improvement**), with much less deviation.
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_api-requests.png"
-     alt="Request rate to the API between 16:30 and 22:30 on 10/06/18 with a -7 day timeshift."
-     title="Request rate to the API between 16:30 and 22:30 on 10/06/18 with a -7 day timeshift.">
+{{< cdn-image path="api-requests.png" title="Request rate to the API between 16:30 and 22:30 on 10/06/18 with a -7 day timeshift." >}}
 
 The overall request rate also is shown to give an indication of the relative load on the API.
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_api-cpu.png"
-     alt="CPU utilisation of the API between 16:30 and 22:30 on 10/06/18 with a -7 day timeshift."
-     title="CPU utilisation of the API between 16:30 and 22:30 on 10/06/18 with a -7 day timeshift.">
+{{< cdn-image path="api-cpu.png" title="CPU utilisation of the API between 16:30 and 22:30 on 10/06/18 with a -7 day timeshift." >}}
 
 CPU usage is also illustrated, which again shows a slight overall improvement. The spike in the graph is where auto-scaling
 increased the number of EC2 instances in service based on average CPU load.
 
 ### Web
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_web-response-times.png"
-     alt="Response times from the web application between 16:30 and 22:30 on 10/06/18 with a -7 day timeshift."
-     title="Response times from the web application between 16:30 and 22:30 on 10/06/18 with a -7 day timeshift.">
+{{< cdn-image path="web-response-times.png" title="Response times from the web application between 16:30 and 22:30 on 10/06/18 with a -7 day timeshift." >}}
 
 The web app averaged `130ms` per page render compared to `230ms` (**approximately a 43% improvement**) which again shows
 much less deviation.
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_web-requests.png"
-     alt="Request rate to the web application between 16:30 and 22:30 on 10/06/18 with a -7 day timeshift."
-     title="Request rate to the web application between 16:30 and 22:30 on 10/06/18 with a -7 day timeshift.">
+{{< cdn-image path="web-requests.png" title="Request rate to the web application between 16:30 and 22:30 on 10/06/18 with a -7 day timeshift." >}}
 
 The overall request rate also is shown to give an indication of the relative load on the web application.
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_web-cpu.png"
-     alt="CPU utilisation of the website between 16:30 and 22:30 on 10/06/18 with a -7 day timeshift."
-     title="CPU utilisation of the website between 16:30 and 22:30 on 10/06/18 with a -7 day timeshift.">
+{{< cdn-image path="web-cpu.png" title="CPU utilisation of the website between 16:30 and 22:30 on 10/06/18 with a -7 day timeshift." >}}
 
 CPU usage is also illustrated, which again shows a slight overall improvement. The spikes in the graph is where auto-scaling
 increased the number of EC2 instances in service based on average CPU load.

--- a/content/posts/aspnet-core-pseudo-localization.md
+++ b/content/posts/aspnet-core-pseudo-localization.md
@@ -115,11 +115,11 @@ _Apologies if you speak French, German, Japanese or Spanish and the text isn't..
 
 Below is a screenshot of the application when set to use UK English.
 
-<img class="img-fluid mx-auto d-block" src="https://cdn.martincostello.com/blog_todoapp-english.png" alt="Todo application in UK English" title="Todo application in UK English">
+{{< cdn-image path="todoapp-english.png" title="Todo application in UK English" >}}
 
 Below is a screenshot of the application when the language is changed to the pseudo-locale. Notice that all of the text has been updated except for the user-provided Todo items' descriptions. Even the operating system-formatted date has been changed.
 
-<img class="img-fluid mx-auto d-block" src="https://cdn.martincostello.com/blog_todoapp-pseudo.png" alt="Todo application in pseudo-localized English" title="Todo application in pseudo-localized English">
+{{< cdn-image path="todoapp-pseudo.png" title="Todo application in pseudo-localized English" >}}
 
 You can find the source `.resx` file [here](https://github.com/martincostello/aspnet-core-pseudo-localization/blob/main/src/TodoApp/Resources.resx "Resources.resx") and the `.xlf` files [here](https://github.com/martincostello/aspnet-core-pseudo-localization/tree/main/src/TodoApp/xlf "xlf files").
 

--- a/content/posts/bringing-apple-pay-to-the-web.md
+++ b/content/posts/bringing-apple-pay-to-the-web.md
@@ -653,15 +653,9 @@ postcode provided by the user in the case of a delivery order.
 Once the user authorizes payment with their finger or thumb, the sheet is dismissed, they are logged in
 to a guest account if not already logged in, and redirected to the order confirmation page.
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_apple-pay-step-1-ios.png"
-     alt="The Apple Pay button displayed during checkout in Safari on iOS 10."
-     title="The Apple Pay button displayed during checkout in Safari on iOS 10.">
+{{< cdn-image path="apple-pay-step-1-ios.png" title="The Apple Pay button displayed during checkout in Safari on iOS 10." >}}
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_apple-pay-step-2-ios.png"
-     alt="The Apple Pay payment sheet in iOS."
-     title="The Apple Pay payment sheet in iOS.">
+{{< cdn-image path="apple-pay-step-2-ios.png" title="The Apple Pay payment sheet in iOS." >}}
 
 ### macOS payment flow
 
@@ -671,10 +665,7 @@ delivered for (or be ready for collection) and an optional note for the restaura
 Here the user is shown the Apple Pay button in additional to the usual button to continue through checkout
 to provide their delivery and payment details.
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_apple-pay-step-1-macos.png"
-     alt="The Apple Pay button displayed during checkout in Safari on macOS Sierra."
-     title="The Apple Pay button displayed during checkout in Safari on macOS Sierra.">
+{{< cdn-image path="apple-pay-step-1-macos.png" title="The Apple Pay button displayed during checkout in Safari on macOS Sierra." >}}
 
 The user clicks the Apple Pay button and the Apple sheet is displayed. The user selects their payment
 card as well as their delivery address. While this happens we asynchronously validate the merchant session
@@ -682,23 +673,14 @@ to enable the ability to authorize payment using an iPhone, iPad or Apple Watch 
 iCloud account, as well as validate that the restaurant selected delivers to the postcode provided by the
 user in the case of a delivery order.
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_apple-pay-step-2-macos.png"
-     alt="The Apple Pay payment sheet in macOS Sierra."
-     title="The Apple Pay payment sheet in macOS Sierra.">
+{{< cdn-image path="apple-pay-step-2-macos.png" title="The Apple Pay payment sheet in macOS Sierra." >}}
 
 Once the merchant session is validated, the user is then prompted to authorize the payment on their paired
 device, for example using either an iPhone with TouchID or an Apple Watch.
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_apple-pay-step-3-macos.png"
-     alt="Payment confirmation for a purchase from macOS using Touch ID on an iPhone."
-     title="Payment confirmation for a purchase from macOS using Touch ID on an iPhone.">
+{{< cdn-image path="apple-pay-step-3-macos.png" title="Payment confirmation for a purchase from macOS using Touch ID on an iPhone." >}}
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_apple-pay-step-3-watchos.png"
-     alt="Payment confirmation for a purchase from macOS using Apple Watch."
-     title="Payment confirmation for a purchase from macOS using Apple Watch.">
+{{< cdn-image path="apple-pay-step-3-watchos.png" title="Payment confirmation for a purchase from macOS using Apple Watch." >}}
 
 Once the user authorizes payment with their finger or thumb with TouchID or by pressing a button on their
 Apple Watch, the sheet is dismissed, they are logged in to a guest account if not already logged in, and

--- a/content/posts/browserstack-automate-api-client-v2.md
+++ b/content/posts/browserstack-automate-api-client-v2.md
@@ -4,7 +4,7 @@ date: 2016-10-18
 tags: browserstack,automate,dotnet core,
 layout: post
 description: "BrowserStack Automate API client 2.0.1 released - now supporting .NET Core!"
-image: "https://cdn.martincostello.com/blog_browserstack-logo.png"
+cdnImage: "browserstack-logo.png"
 ---
 
 I've just released [version 2.0.1](https://www.nuget.org/packages/MartinCostello.BrowserStack.Automate) of the [BrowserStack Automate](https://www.browserstack.com/automate) .NET client open source project that I maintain on [GitHub](https://martincostello.github.io/browserstack-automate/).

--- a/content/posts/continuous-benchmarks-on-a-budget.md
+++ b/content/posts/continuous-benchmarks-on-a-budget.md
@@ -4,13 +4,10 @@ date: 2024-09-23
 tags: actions,benchmarks,benchmarkdotnet,ci,dotnet,github
 layout: post
 description: "Using GitHub Actions, GitHub Pages and Blazor to run and visualise continuous benchmarks with BenchmarkDotNet with zero hosting costs."
-image: "https://cdn.martincostello.com/blog_benchmarks-regression.png"
+cdnImage: "benchmarks-regression.png"
 ---
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_benchmarks-regression.png"
-     alt="A chart showing a time series for performance and memory usage with an increase in memory usage in the most recent data points"
-     title="A chart showing a time series for performance and memory usage with an increase in memory usage in the most recent data points">
+{{< cdn-image path="benchmarks-regression.png" title="A chart showing a time series for performance and memory usage with an increase in memory usage in the most recent data points" >}}
 
 Over the last few months I've been doing a bunch of testing with the [new OpenAPI support in .NET 9][openapi-post].
 As part of that testing, I wanted to take a look at how the performance of the new libraries compared to the existing
@@ -211,17 +208,11 @@ to serve it over.
 
 With all the pieces in place, at a high-level the solution looks something like this:
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_benchmarks-workflow.png"
-     alt="A sequence diagram showing how the application, data and dashboard repositories interact to render charts"
-     title="A sequence diagram showing how the application, data and dashboard repositories interact to render charts">
+{{< cdn-image path="benchmarks-workflow.png" title="A sequence diagram showing how the application, data and dashboard repositories interact to render charts" >}}
 
 Which for the end-user (i.e. me) gives a nice interactive dashboard to visualise the results like this:
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_benchmarks-dashboard.png"
-     alt="A screenshot of the dashboard website showing two charts of time and memory consumption for a branch of a GitHub repository"
-     title="A screenshot of the dashboard website showing two charts of time and memory consumption for a branch of a GitHub repository">
+{{< cdn-image path="benchmarks-dashboard.png" title="A screenshot of the dashboard website showing two charts of time and memory consumption for a branch of a GitHub repository" >}}
 
 I've set up a demo repository ([martincostello/benchmarks-demo][benchmarks-demo]) that you can use as an inspiration for setting
 up some Benchmark.NET benchmarks and then using a GitHub Actions workflow to run them and publish them to another repository.
@@ -247,17 +238,11 @@ case for the majority of the benchmarks, but there was one benchmark that bucked
 Going back to the chart shown at the top of this blog post, you can see that the red line denoting memory usage has a noticeable,
 and consistent, uptick a few commits ago:
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_benchmarks-regression.png"
-     alt="A chart showing a time series for performance and memory usage with an increase in memory usage in the most recent data points"
-     title="A chart showing a time series for performance and memory usage with an increase in memory usage in the most recent data points">
+{{< cdn-image path="benchmarks-regression.png" title="A chart showing a time series for performance and memory usage with an increase in memory usage in the most recent data points" >}}
 
 If we hover over the first data point in the uptick, we can see that the change is from the upgrade from .NET 8 to .NET 9 RC1:
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_benchmarks-regression-tooltip.png"
-     alt="The above chart with a tooltip showing the Git commit associated with the increase in memory usage"
-     title="The above chart with a tooltip showing the Git commit associated with the increase in memory usage">
+{{< cdn-image path="benchmarks-regression-tooltip.png" title="The above chart with a tooltip showing the Git commit associated with the increase in memory usage" >}}
 
 I hadn't spotted this regression previously as the benchmark data is something I'd started collecting relatively recently, and the trends
 didn't go back far enough to show the regression at the time it was made through my testing of the .NET 9 pre-releases. It was only when

--- a/content/posts/github-codespaces-gotchas-with-aspnetcore-oauth.md
+++ b/content/posts/github-codespaces-gotchas-with-aspnetcore-oauth.md
@@ -25,7 +25,7 @@ bit of time to bed-in and sort out), I found that whenever I tried to log in to
 the sample application using the Codespaces preview URL when I ran it in the
 debugger, I'd be greeted with an HTTP 405 error ([Method Not Allowed][14]).
 
-<img class="img-fluid mx-auto d-block" src="https://cdn.martincostello.com/blog_http-405.png" alt="HTTP 405 error" title="HTTP 405 error">
+{{< cdn-image path="http-405.png" title="HTTP 405 error" >}}
 
 However, the error page wasn't coming from my app. The `Server` HTTP response
 header identified it as NGINX, and turning up the default log level to `Trace`

--- a/content/posts/improving-asp-net-core-before-it-ships.md
+++ b/content/posts/improving-asp-net-core-before-it-ships.md
@@ -4,7 +4,7 @@ date: 2022-05-03
 tags: dotnet,aspnetcore,performance
 layout: post
 description: "Upgrading to ASP.NET Core 2.1 can deliver serious performance improvements to your web applications as well as make you much more productive as a developer."
-image: "https://cdn.martincostello.com/blog_deadlock-parallel-stacks.webp"
+cdnImage: "deadlock-parallel-stacks.webp"
 ---
 
 > _This blog post was originally published by me on the [Just Eat Tech blog][original-post]._
@@ -54,10 +54,7 @@ system fired up and paged the on-call engineer for the application. Clients of t
 request timeouts and HTTP 503 errors. Looking at the AWS Auto Scaling Group for the app showed that there appeared
 to be no healthy instances. This seemed like a classic case of an application [deadlock][deadlock].
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_deadlock-request-rate.webp"
-     alt="HTTP requests to the application when the deadlock occurred."
-     title="HTTP requests to the application when the deadlock occurred.">
+{{< cdn-image path="deadlock-request-rate.webp" title="HTTP requests to the application when the deadlock occurred." >}}
 
 We deployed the changes hours ago and had no issues with previews and all our tests had passed — what had gone wrong?
 🤔 The app self-healed within 20 minutes, we rolled back to the old version and started to look into it.
@@ -122,10 +119,7 @@ stacks showed that one stack was waiting on another stack and vice-versa (there 
 Threads for user requests were waiting on a lock held by reloading the config. The thread reloading the config was
 waiting on a lock held by those user requests. Here was our deadlock!
 
-<img class="img-fluid mx-auto d-block"
-     src="https://cdn.martincostello.com/blog_deadlock-parallel-stacks.webp"
-     alt="The parallel stacks in the deadlocked application."
-     title="The parallel stacks in the deadlocked application.">
+{{< cdn-image path="deadlock-parallel-stacks.webp" title="The parallel stacks in the deadlocked application." >}}
 
 ## Getting the Bug Fixed 🐛🔧
 

--- a/content/posts/integration-testing-lambda-with-dotnet-custom-runtime.md
+++ b/content/posts/integration-testing-lambda-with-dotnet-custom-runtime.md
@@ -4,7 +4,7 @@ date: 2019-11-11
 tags: aws,dotnet,lambda,testing
 layout: post
 description: "Using Lambda Test Server to integration test your C# AWS Lambda functions for .NET Core locally when using a custom runtime."
-image: "https://cdn.martincostello.com/blog_lambda-dotnet-core.png"
+cdnImage: "lambda-dotnet-core.png"
 ---
 
 _Lambda Test Server_ is a .NET Core 3.0 library available from [NuGet](https://www.nuget.org/packages/MartinCostello.Testing.AwsLambdaTestServer/ "MartinCostello.Testing.AwsLambdaTestServer on NuGet.org") which builds on top of the [`TestServer`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.testhost.testserver "TestServer Class on Microsoft Docs") class in the [Microsoft.AspNetCore.TestHost NuGet package](https://www.nuget.org/packages/Microsoft.AspNetCore.TestHost/ "Microsoft.AspNetCore.TestHost on NuGet.org") to provide infrastructure to use with end-to-end/integration tests for .NET Core AWS Lambda Functions using a [custom runtime](https://aws.amazon.com/blogs/developer/net-core-3-0-on-lambda-with-aws-lambdas-custom-runtime/ ".NET Core 3.0 on Lambda with AWS Lambda’s Custom Runtime").

--- a/content/posts/look-ma-no-hands-publishing-containers-with-the-dotnet-sdk.md
+++ b/content/posts/look-ma-no-hands-publishing-containers-with-the-dotnet-sdk.md
@@ -4,10 +4,10 @@ date: 2024-05-02
 tags: containers,docker,dotnet
 layout: post
 description: "Publishing a .NET application as a container image using the .NET SDK without needing a Dockerfile and attesting the provenance of the image with GitHub Actions."
-image: "https://cdn.martincostello.com/blog_dotnet-containers.jpg"
+cdnImage: "dotnet-containers.jpg"
 ---
 
-<img class="img-fluid mx-auto d-block" src="https://cdn.martincostello.com/blog_dotnet-containers.jpg" alt="A container ship being loaded with the .NET logo on the stern" title="A container ship being loaded with the .NET logo on the stern" height="384px" width="757px">
+{{< cdn-image path="dotnet-containers.jpg" title="A container ship being loaded with the .NET logo on the stern" height="384px" width="757px" >}}
 
 Containers have been a thing in the software ecosystem for a few years now, with lots of associated technologies and
 concepts - Docker, Kubernetes, Helm charts, sidecars and many more. Using containers simplifies the deployment of your

--- a/content/posts/migrating-from-iis-to-s3.md
+++ b/content/posts/migrating-from-iis-to-s3.md
@@ -4,7 +4,7 @@ date: 2017-08-28
 tags: aws,cloudfront,lambda,lambda@edge,s3
 layout: post
 description: "Migrating a static website from being hosted with IIS in Azure to S3, CloudFront and Lambda@Edge in AWS."
-image: "https://cdn.martincostello.com/blog_amazon-simple-storage-service.png"
+cdnImage: "amazon-simple-storage-service.png"
 ---
 
 Since I set up my blog in March 2014, it's been running in IIS as part of an Azure App Service. Initially this was required as the blog was originally a WordPress site, so a server was required to run the PHP code for WordPress. However when I got fed up with keeping WordPress up-to-date and [migrated to a static Middleman site](/why-i-switched-from-wordpress-to-middleman/ "Why I Switched From WordPress To Middleman"), I left it hosted in Azure. This was mainly because it was the easiest option, as that's where it was already, but also because this allowed me to specify HTTP response headers still, such as for `X-Frame-Options`.
@@ -21,27 +21,23 @@ Things were already in a fairly good starting point for the migration. The code 
 
 So to start I needed an S3 bucket. I had actually already created an S3 bucket last year after I found out that your bucket has to have the _exact_ same name as your DNS hostname for the website you want to host, so I wanted to make sure it belonged to me. However, when I'd set it up I'd set it up in the wrong region. No biggie, I'll just delete it and recreate it right? Almost.
 
-<img class="img-fluid mx-auto d-block" src="https://cdn.martincostello.com/blog_one-does-not-simply-recreate-an-s3-bucket.jpg" alt="One does not simply recreate an S3 bucket" title="One does not simply recreate an S3 bucket">
+{{< cdn-image path="one-does-not-simply-recreate-an-s3-bucket.jpg" title="One does not simply recreate an S3 bucket" >}}
 
 Turns out that because S3 bucket names are global and because S3 is a distributed system, **fully** deleting an S3 bucket actually takes a non-trivial amount of time. Once I deleted the bucket from the AWS Console, I tried to recreate it in a new region. This failed immediately in the wizard for the first minute or so because it said that a DNS entry for the bucket already existed. Once that error resolved itself I could continue through the wizard to set things up, but it would then fail on the final step with the error:
 
-<blockquote class="blockquote">
-  <p class="mb-0">
-    A conflicting conditional operation is currently in progress against this resource. Please try again.
-  </p>
-</blockquote>
+> A conflicting conditional operation is currently in progress against this resource. Please try again.
 
 What? A quick search turns up this [answer on StackOverflow](https://stackoverflow.com/a/16553056/1064169 "Answer on StackOverflow for the error message"). Turns out I just need to wait. For an hour.
 
-<img class="img-fluid mx-auto d-block" src="https://cdn.martincostello.com/blog_homer-simpson-chair-goes-round.gif" alt="Chair goes round, chair goes round..." title="Chair goes round, chair goes round...">
+{{< cdn-image path="homer-simpson-chair-goes-round.gif" title="Chair goes round, chair goes round..." >}}
 
 With the S3 bucket effectively moved, it needs configuring to enable Static website hosting with the appropriate index and error pages.
 
 Once I've got the S3 bucket created in the correct region, I could press on. The steps were fairly simple:
 
   1. Add a deployment section to the `.travis.yml` file to copy the static content for the site to S3: [configuration](https://github.com/martincostello/blog/blob/5db3f6495e8accaaa567171b871a225c4e0f8d57/.travis.yml#L18-L28 "S3 deployment configuration in GitHub").
-  1. Copy my TLS certificate to Amazon Certificate Manager in `us-east-1`.
-  1. Set up a new CloudFront web distribution to serve the content from the S3 bucket (more waiting) with a CNAME for `blog.martincostello.com`.
+  2. Copy my TLS certificate to Amazon Certificate Manager in `us-east-1`.
+  3. Set up a new CloudFront web distribution to serve the content from the S3 bucket (more waiting) with a CNAME for `blog.martincostello.com`.
   1. Configure a custom 404 error page for the distribution.
 
 ## Migrating the HTTP Response Headers
@@ -66,9 +62,9 @@ One gotcha with Lambda@Edge though, is the way it handles deployment. The functi
 
 I hope that this is something AWS improve the developer experience for in the future so that it's easy to deploy on a rolling basis like the static content is to S3 from Travis CI, rather than something requiring continual manual intervention.
 
-<img class="img-fluid mx-auto d-block" src="https://cdn.martincostello.com/blog_lambda-edge-function-trigger.png" alt="Lambda@Edge function trigger" title="Lambda@Edge function trigger">
+{{< cdn-image path="lambda-edge-function-trigger.png" title="Lambda@Edge function trigger" >}}
 
-<img class="img-fluid mx-auto d-block" src="https://cdn.martincostello.com/blog_lambda-edge-function-replica.png" alt="Lambda@Edge function replica" title="Lambda@Edge function replica">
+{{< cdn-image path="lambda-edge-function-replica.png" title="Lambda@Edge function replica" >}}
 
 ### Permissions Policy
 

--- a/content/posts/native-aot-make-dotnet-lambda-go-brr.md
+++ b/content/posts/native-aot-make-dotnet-lambda-go-brr.md
@@ -4,10 +4,10 @@ date: 2023-11-29
 tags: aot,aws,dotnet,lambda
 layout: post
 description: "Upgrading a .NET AWS Lambda function to use native AoT for improved cold-start performance by over 85%."
-image: "https://cdn.martincostello.com/blog_lambda-go-brr.png"
+cdnImage: "lambda-go-brr.png"
 ---
 
-<img class="img-fluid mx-auto d-block" src="https://cdn.martincostello.com/blog_lambda-go-brr.png" alt="The AWS Lambda logo overlaid with the .NET logo wth some fire emojis added" title="The AWS Lambda logo overlaid with the .NET logo wth some fire emojis added" height="384px" width="384px">
+{{< cdn-image path="lambda-go-brr.png" title="The AWS Lambda logo overlaid with the .NET logo wth some fire emojis added" height="384px" width="384px" >}}
 
 Since 2017 I've been maintaining an Alexa skill, [_London Travel_][london-travel], that provides real-time information about the status of London Underground, London Overground, and the DLR (and the Elizabeth Line). The skill is an AWS Lambda function, [originally implemented in Node.js][publishing-my-first-alexa-skill], but [since 2019][integrating-testing-dotnet-lambda-functions] it  has been implemented in .NET.
 
@@ -227,7 +227,7 @@ All-in-all it was a fun learning experience converting my first .NET application
 
 I think this image of the _Duration minimum_ metric from CloudWatch for the Lambda function over the last 2 weeks says it all. Spot when the changes were deployed... 🚀
 
-<img class="img-fluid mx-auto d-block" src="https://cdn.martincostello.com/blog_aot-lambda-cloudwatch-metrics.png" alt="An AWS CloudWatch graph of the Duration minimum metric with a pronounced decrease and consistency of the Duration in milliseconds of the Lambda function invocations since 27th November" title="An AWS CloudWatch graph of the Duration minimum metric with a pronounced decrease and consistency of the Duration in milliseconds of the Lambda function invocations since 27th November">
+{{< cdn-image path="aot-lambda-cloudwatch-metrics.png" title="An AWS CloudWatch graph of the Duration minimum metric with a pronounced decrease and consistency of the Duration in milliseconds of the Lambda function invocations since 27th November" >}}
 
 To summarise, the net effect of converting my Alexa skill's Lambda function to use native AoT are:
 

--- a/content/posts/refit-and-system-text-json.md
+++ b/content/posts/refit-and-system-text-json.md
@@ -140,7 +140,7 @@ The results are fairly impressive on my laptop running Windows 10 ([full results
   </tbody>
 </table>
 
-<hr/>
+---
 
 For these specific example requests and responses, for reading an object **the mean time per operation is reduced by 87%** and the amount of **memory allocated reduced by 55%**!
 

--- a/content/posts/upgrading-to-dotnet-8-part-1-why-upgrade.md
+++ b/content/posts/upgrading-to-dotnet-8-part-1-why-upgrade.md
@@ -4,7 +4,7 @@ date: 2023-07-10
 tags: dotnet,preview,upgrade
 layout: post
 description: "Why should you upgrade to .NET 8?"
-image: "https://cdn.martincostello.com/blog_spiderman-upgrades.jpg"
+cdnImage: "spiderman-upgrades.jpg"
 ---
 
 Another year, another new major version of .NET is coming - .NET **8**, to be specific.
@@ -19,7 +19,7 @@ Long Term Support (LTS) release ([see here][dotnet-release-types]).
 
 There's a nice graphic here from the .NET website that illustrates how things look today:
 
-<img class="img-fluid mx-auto d-block" src="https://cdn.martincostello.com/blog_dotnet-8-releases.svg" alt="A timeline showing the support for .NET 5 in 2020 through to .NET 9 in 2024" title="A timeline showing the support for .NET 5 in 2020 through to .NET 9 in 2024">
+{{< cdn-image path="dotnet-8-releases.svg" title="A timeline showing the support for .NET 5 in 2020 through to .NET 9 in 2024" >}}
 
 That means .NET 8 will be the next LTS release and supercede .NET 6 _and also_ .NET 7 by the end of 2024.
 
@@ -44,7 +44,7 @@ but these are typically few in number and are usually easy to fix.
 
 This screenshot from the talk illustrates the sort of improvements you can expect to see from a simple upgrade.
 
-<img class="img-fluid mx-auto d-block" src="https://cdn.martincostello.com/blog_dotnet-8-performance.png" alt="A bar chart comparing the requests per second gained by upgrading from .NET Core 3.1 to .NET 5, 6, 7 and 8 preview 4" title="A bar chart comparing the requests per second gained by upgrading from .NET Core 3.1 to .NET 5, 6, 7 and 8 preview 4">
+{{< cdn-image path="dotnet-8-performance.png" title="A bar chart comparing the requests per second gained by upgrading from .NET Core 3.1 to .NET 5, 6, 7 and 8 preview 4" >}}
 
 That makes it seem like a no-brainer to upgrade to me. With lots of people being cost concious these days,
 [penny pinching in the cloud][penny-pinching] can be a big deal, and small improvements magnified across
@@ -78,7 +78,7 @@ This gives us a high confidence to adopt the latest .NET releases as soon as the
 a period of time for them to _"bake in"_ by letting others [step on the rakes][rakes] for us. If everyone did that,
 no one would ever upgrade anything!
 
-<img class="img-fluid mx-auto d-block" src="https://cdn.martincostello.com/blog_spiderman-upgrades.jpg" alt="Meme of three Spider-Men pointing at each other about upgrading .NET" title="Meme of three Spider-Men pointing at each other about upgrading .NET">
+{{< cdn-image path="spiderman-upgrades.jpg" title="Meme of three Spider-Men pointing at each other about upgrading .NET" >}}
 
 ## What's in this series?
 

--- a/content/posts/upgrading-to-dotnet-8-part-2-automation-is-our-friend.md
+++ b/content/posts/upgrading-to-dotnet-8-part-2-automation-is-our-friend.md
@@ -4,7 +4,7 @@ date: 2023-07-11
 tags: dotnet,preview,upgrade,automation,github,actions
 layout: post
 description: "Making it easier to test .NET previews using GitHub Actions for on-going automation."
-image: "https://cdn.martincostello.com/blog_dotnet-8-upgrade-report.png"
+cdnImage: "dotnet-8-upgrade-report.png"
 ---
 
 In [part 1 of this series][part-1] I recommended that you prepare to upgrade to .NET 8 and suggested
@@ -139,7 +139,7 @@ change that needs some manual intervention. In these cases, Rebaser can do the h
 At this point we have a workflow that does our version updates for us and another that rebases the branch when it
 needs it, but both of these workflows need to be run manually. That's not very automated, is it?
 
-<img class="img-fluid mx-auto d-block" src="https://cdn.martincostello.com/blog_an-automated-solution.gif" alt="A drinking bird pressing a button on a keyboard" title="A drinking bird pressing a button on a keyboard">
+{{< cdn-image path="an-automated-solution.gif" title="A drinking bird pressing a button on a keyboard" >}}
 
 What if we could automate the automation (whoa, meta) to run the workflows for us when we need them to? What if we
 could run the workflows for _all_ of the repositories we're testing .NET previews with? That sounds like something
@@ -151,7 +151,7 @@ that would really save us some time each month.
 - When changes are found, which _usually_ implies a new release is available, the workflow [raises a repository dispatch event][github-api-create-repo-dispatch] named `dotnet_release`.
 - This event triggers the [`update-dotnet-sdks`][update-dotnet-sdks] workflow which runs the `update-dotnet-sdk` workflow in each repository that has opted-in to the automation for the `main` branch. This isn't run for `dotnet-vnext` at the moment as when the release notes change there's likely a new version of .NET 6, 7 and 8 at the same time. Running just for `main` means we can get the .NET 6/7 updates applied to it first, and then the .NET 8 updates later as it would just create a merge conflict anyway.
 
-<s>In the future I might extend this to be smarter and determine whether a preview (or not) has been released, and then run the workflow for either `main` or `dotnet-vnext` as appropriate.</s>
+~~In the future I might extend this to be smarter and determine whether a preview (or not) has been released, and then run the workflow for either `main` or `dotnet-vnext` as appropriate.~~
 
 I updated the workflow above to handle this scenario. It now checks the `release-notes/**/releases.json` file(s) for the latest version(s) of .NET that have been released. If any version is a preview, then it will run the workflow for `dotnet-vnext`; for any others it will run the workflow for `main`. The commit that made those changes can be [found here][improvement-commit].
 
@@ -164,7 +164,7 @@ I updated the workflow above to handle this scenario. It now checks the `release
 A sequence diagram of how all the workflows and events fit together is shown below.
 
 <a href="https://github.com/martincostello/github-automation/blob/main/docs/dotnet-vnext.md#sequence-diagram" target="_blank">
-  <img class="img-fluid mx-auto d-block" src="https://cdn.martincostello.com/blog_dotnet-vnext-sequence.png" alt="A sequence diagram showing the automated workflow" title="A sequence diagram showing the automated workflow">
+  {{< cdn-image path="dotnet-vnext-sequence.png" title="A sequence diagram showing the automated workflow" >}}
 </a>
 
 More detailed information about how the workflows above operate can be found in _[Testing .NET vNext][dotnet-vnext]_.
@@ -190,7 +190,7 @@ any rows that might be of interest. An example of the report can be found [here]
 
 Here's a snippet from one as an example:
 
-<img class="img-fluid mx-auto d-block w-75" src="https://cdn.martincostello.com/blog_dotnet-8-upgrade-report.png" alt="An example upgrade report showing the status of 9 repositories' upgrades" title="An example upgrade report showing the status of 9 repositories' upgrades">
+{{< cdn-image path="dotnet-8-upgrade-report.png" title="An example upgrade report showing the status of 9 repositories' upgrades" class="img-fluid mx-auto d-block w-75" >}}
 
 As you can see above, at the time the report was generated all of the repositories' CI were passing and
 using the latest .NET 8 preview SDK, but the [adventofcode repository][advent-of-code] had a merge
@@ -232,7 +232,7 @@ a lot of the boring parts of upgrading from one .NET preview to the next. These 
 
 - Watch for new .NET versions using the JSON release notes
 - Use the [update-dotnet-sdk] GitHub action to update the .NET SDK and NuGet packages for the repositories we're testing
-- Keep changes that break the CI in a separate branch and pull request for manual inspection <s>if</s> when an issue is found
+- Keep changes that break the CI in a separate branch and pull request for manual inspection ~~if~~ when an issue is found
 - Automatically rebase the `dotnet-vnext` branch as and when needed (or make it easier to do so manually)
 
 With these parts automated, we can focus on the more interesting parts of the process that come up, like any issues we

--- a/content/posts/upgrading-to-dotnet-8-part-3-previews-1-to-5.md
+++ b/content/posts/upgrading-to-dotnet-8-part-3-previews-1-to-5.md
@@ -4,7 +4,7 @@ date: 2023-07-12
 tags: dotnet,preview,upgrade
 layout: post
 description: "Highlights from upgrading to .NET 8 previews 1-5"
-image: "https://cdn.martincostello.com/blog_dotnet-bot.png"
+cdnImage: "dotnet-bot.png"
 ---
 
 In the [previous post of this series][part-2] I described how with some
@@ -74,7 +74,7 @@ This opt-in change allows you to change from having a separate `bin` and `obj` f
 per project to instead have a single `artifacts` folder in the root of the solution
 directory that instead contains all of the output from your build and publish steps.
 
-<img class="img-fluid mx-auto d-block w-75" src="https://cdn.martincostello.com/blog_artifacts-output.png" alt="The new artifacts output folder" title="The new artifacts output folder">
+{{< cdn-image path="artifacts-output.png" title="The new artifacts output folder" class="img-fluid mx-auto d-block w-75" >}}
 
 This makes it much easier to find the output artifacts for your application and
 process them, such as when deploying an application to a remote server or

--- a/content/posts/upgrading-to-dotnet-8-part-4-preview-6.md
+++ b/content/posts/upgrading-to-dotnet-8-part-4-preview-6.md
@@ -4,7 +4,7 @@ date: 2023-07-19
 tags: dotnet,preview,upgrade
 layout: post
 description: "Highlights from upgrading to .NET 8 preview 6"
-image: "https://cdn.martincostello.com/blog_dotnet-bot.png"
+cdnImage: "dotnet-bot.png"
 ---
 
 Following on from [part 3][part-3] of this series, I've been continuing

--- a/content/posts/upgrading-to-dotnet-8-part-5-preview-7-and-rc-1-2.md
+++ b/content/posts/upgrading-to-dotnet-8-part-5-preview-7-and-rc-1-2.md
@@ -4,7 +4,7 @@ date: 2023-10-13
 tags: dotnet,preview,upgrade
 layout: post
 description: "Highlights from upgrading to .NET 8 preview 7 and release candidates 1 and 2"
-image: "https://cdn.martincostello.com/blog_dotnet-bot.png"
+cdnImage: "dotnet-bot.png"
 ---
 
 This post is a bumper edition, covering three different releases:
@@ -190,7 +190,7 @@ response times for requests!
 
 Spot where the code change got deployed... 🕵️
 
-<img class="img-fluid mx-auto d-block" src="https://cdn.martincostello.com/blog_jsonserializeroptions-too-slow.png" alt="A graph showing the performance impact of the bad change" title="A graph showing the performance impact of the bad change">
+{{< cdn-image path="jsonserializeroptions-too-slow.png" title="A graph showing the performance impact of the bad change" >}}
 
 While in this case the analyzer may not have helped as it was an issue with the dependency injection configuration, it's good to
 know that investment has been made to help avoid developers causing the same problem in different scenarios.

--- a/content/posts/upgrading-to-dotnet-8-part-6-stable-release.md
+++ b/content/posts/upgrading-to-dotnet-8-part-6-stable-release.md
@@ -4,14 +4,14 @@ date: 2023-11-20
 tags: dotnet,preview,upgrade
 layout: post
 description: "Highlights from upgrading to the stable release of .NET 8"
-image: "https://cdn.martincostello.com/blog_dotnet-bot.png"
+cdnImage: "dotnet-bot.png"
 ---
 
 Last week at [.NET Conf 2023][dotnet-conf], the stable release of .NET 8 was released as the latest [Long Term Support][dotnet-support-policy] (LTS) release of the .NET platform.
 
 With the release of .NET 8.0.0 and the end of the preview releases, my past week can be summed up by the following image:
 
-<img class="img-fluid mx-auto d-block" src="https://cdn.martincostello.com/blog_upgrade-all-the-things.jpg" alt="The All the Things meme, with the text: Upgrade All The Things To .NET 8" title="The All the Things meme, with the text: Upgrade All The Things To .NET 8">
+{{< cdn-image path="upgrade-all-the-things.jpg" title="The All the Things meme, with the text: Upgrade All The Things To .NET 8" >}}
 
 <!--more-->
 

--- a/content/posts/whats-new-for-openapi-with-dotnet-9.md
+++ b/content/posts/whats-new-for-openapi-with-dotnet-9.md
@@ -4,10 +4,10 @@ date: 2024-09-09
 tags: dotnet,openapi,swagger,swashbuckle
 layout: post
 description: "A look at the new Microsoft.AspNetCore.OpenApi package in .NET 9 and comparing it to NSwag and Swashbuckle.AspNetCore."
-image: "https://cdn.martincostello.com/blog_openapi.png"
+cdnImage: "openapi.png"
 ---
 
-<img class="img-fluid mx-auto d-block" src="https://cdn.martincostello.com/blog_openapi.png" alt="The OpenAPI logo" title="The OpenAPI logo" height="272px" width="899px">
+{{< cdn-image path="openapi.png" title="The OpenAPI logo" height="272px" width="899px" >}}
 
 Developers in the .NET ecosystem have been writing APIs with ASP.NET and ASP.NET Core for years, and
 [OpenAPI][openapi] has been a popular choice for documenting those APIs.
@@ -329,13 +329,13 @@ a lot of variance in the OpenAPI package's performance, compared to the other tw
 <div class="container mx-1">
   <div class="row">
     <div class="col">
-      <img class="img-fluid" src="https://cdn.martincostello.com/blog_openapi-aspnetcore-preview7.png" alt="ASP.NET Core results for .NET 9 preview 7" title="ASP.NET Core results for .NET 9 preview 7" >
+      {{< cdn-image path="openapi-aspnetcore-preview7.png" title="ASP.NET Core results for .NET 9 preview 7" class="img-fluid" >}}
     </div>
     <div class="col">
-      <img class="img-fluid" src="https://cdn.martincostello.com/blog_openapi-nswag-preview7.png" alt="NSwag results for .NET 9 preview 7" title="NSwag results for .NET 9 preview 7">
+      {{< cdn-image path="openapi-nswag-preview7.png" title="NSwag results for .NET 9 preview 7" class="img-fluid" >}}
     </div>
     <div class="col">
-      <img class="img-fluid" src="https://cdn.martincostello.com/blog_openapi-swashbuckle-preview7.png" alt="Swashbuckle results for .NET 9 preview 7" title="Swashbuckle results for .NET 9 preview 7">
+      {{< cdn-image path="openapi-swashbuckle-preview7.png" title="Swashbuckle results for .NET 9 preview 7" class="img-fluid" >}}
     </div>
   </div>
 </div>
@@ -431,13 +431,13 @@ Compared to itself from preview 7, it's now **~11x** faster and allocates **~18x
 <div class="container mx-1">
   <div class="row">
     <div class="col">
-      <img class="img-fluid" src="https://cdn.martincostello.com/blog_openapi-aspnetcore-rc1.png" alt="ASP.NET Core results for .NET 9 preview 7" title="ASP.NET Core results for .NET 9 preview 7" >
+      {{< cdn-image path="openapi-aspnetcore-rc1.png" title="ASP.NET Core results for .NET 9 release candidate 1" class="img-fluid" >}}
     </div>
     <div class="col">
-      <img class="img-fluid" src="https://cdn.martincostello.com/blog_openapi-nswag-rc1.png" alt="NSwag results for .NET 9 preview 7" title="NSwag results for .NET 9 preview 7">
+      {{< cdn-image path="openapi-nswag-rc1.png" title="NSwag results for .NET 9 release candidate 1" class="img-fluid" >}}
     </div>
     <div class="col">
-      <img class="img-fluid" src="https://cdn.martincostello.com/blog_openapi-swashbuckle-rc1.png" alt="Swashbuckle results for .NET 9 preview 7" title="Swashbuckle results for .NET 9 preview 7">
+      {{< cdn-image path="openapi-swashbuckle-rc1.png" title="Swashbuckle results for .NET 9 release candidate 1" class="img-fluid" >}}
     </div>
   </div>
 </div>

--- a/content/posts/writing-logs-to-xunit-test-output.md
+++ b/content/posts/writing-logs-to-xunit-test-output.md
@@ -95,7 +95,9 @@ public sealed class Calculator
 
 As you can see below, the logging output is available in the test results in Visual Studio. If the test were to fail, the output would also be written to the console, such as to diagnose a failing test running in [AppVeyor](https://www.appveyor.com/ "AppVeyor website").
 
+<!-- markdownlint-disable MD033 -->
 <img class="img-fluid mx-auto d-block" src="https://cdn.martincostello.com/xunit-logging-vs-test-output.png" alt="Test output in Visual Studio" title="Test output in Visual Studio">
+<!-- markdownlint-enable MD033 -->
 
 There's also an example of registering the logger for a self-hosted ASP.NET Core application using `WebApplicationFactory<T>` for functional tests in the [sample integration tests](https://github.com/martincostello/xunit-logging/blob/c83d15591df4b5b31f2b40ee43d9b67cf8d628d5/tests/Logging.XUnit.Tests/Integration/HttpApplicationTests.cs "Example HTTP integration tests") in the library's own test project using a sample application.
 

--- a/layouts/_partials/opengraph.html
+++ b/layouts/_partials/opengraph.html
@@ -1,6 +1,8 @@
 <meta property="og:description" content="{{ with .Params.description }}{{ . }}{{ else }}{{ with .Title }}{{ . }}{{ else }}{{ .Site.Params.blogTitle }}{{ end }}{{ end }}" />
 {{- $og_image := "" -}}
-{{- if .Params.image -}}
+{{- if .Params.cdnImage -}}
+    {{- $og_image = printf "https://%s/blog_%s" .Site.Params.cdnDomain .Params.cdnImage -}}
+{{- else if .Params.image -}}
     {{- $og_image = .Params.image -}}
 {{- else -}}
     {{- $og_image = printf "https://%s/martin_small-v3.png" .Site.Params.cdnDomain -}}

--- a/layouts/_shortcodes/cdn-image.html
+++ b/layouts/_shortcodes/cdn-image.html
@@ -1,0 +1,5 @@
+{{- $class := "img-fluid mx-auto d-block" -}}
+{{- if .Params.class -}}
+    {{- $class = .Params.class -}}
+{{- end -}}
+<img src="https://{{ .Site.Params.cdnDomain }}/blog_{{ .Params.path }}" alt="{{ .Params.title }}" title="{{ .Params.title }}" class="{{ $class }}" >

--- a/layouts/_shortcodes/cdn-image.html
+++ b/layouts/_shortcodes/cdn-image.html
@@ -2,4 +2,12 @@
 {{- if .Params.class -}}
     {{- $class = .Params.class -}}
 {{- end -}}
-<img src="https://{{ .Site.Params.cdnDomain }}/blog_{{ .Params.path }}" alt="{{ .Params.title }}" title="{{ .Params.title }}" class="{{ $class }}" >
+{{- $height := "" -}}
+{{- if .Params.height -}}
+    {{- $height = .Params.height -}}
+{{- end -}}
+{{- $width := "" -}}
+{{- if .Params.width -}}
+    {{- $width = .Params.width -}}
+{{- end -}}
+<img src="https://{{ .Site.Params.cdnDomain }}/blog_{{ .Params.path }}" alt="{{ .Params.title }}" title="{{ .Params.title }}" class="{{ $class }}" height="{{ $height }}" width="{{ $width }}" >

--- a/layouts/archive.html
+++ b/layouts/archive.html
@@ -11,15 +11,15 @@
 {{ range where .Site.RegularPages "Layout" "post" }}
 <div class="row">
     <div class="col">
-        <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
+        <h2><a href="{{ .Permalink }}" class="archive-link">{{ .Title }}</a></h2>
         <p>
           <div class="row d-none d-md-block">
                 <div class="col-lg-6">
-                    {{ .Date.Format "2 January 2006" }} by&nbsp;<a href="/about-me/" alt="{{ $.Site.Params.blogAuthor }}" class="archive-link" rel="noopener" title="{{ $.Site.Params.blogAuthor }}">{{ $.Site.Params.blogAuthor }}</a>
+                    {{ .Date.Format "2 January 2006" }} by&nbsp;<a href="/about-me/" alt="{{ $.Site.Params.blogAuthor }}" rel="noopener" title="{{ $.Site.Params.blogAuthor }}">{{ $.Site.Params.blogAuthor }}</a>
                 </div>
             </div>
             <div class="row d-md-none col-12">
-                {{ .Date.Format "2 January 2006" }} by&nbsp;<a href="/about-me/" alt="{{ $.Site.Params.blogAuthor }}" class="archive-link" rel="noopener" title="{{ $.Site.Params.blogAuthor }}">{{ $.Site.Params.blogAuthor }}</a>
+                {{ .Date.Format "2 January 2006" }} by&nbsp;<a href="/about-me/" alt="{{ $.Site.Params.blogAuthor }}" rel="noopener" title="{{ $.Site.Params.blogAuthor }}">{{ $.Site.Params.blogAuthor }}</a>
             </div>
         </p>
     </div>


### PR DESCRIPTION
- Add a shortcode to use CDN images for the blog automatically.
- Add new `cdnImage` frontmatter to use instead of `image`.
- Remove redundant markdownlint rule suppressions.
- Fix incorrect `title` attribute on images.
- Test that all images load.
- Fix incorrect test attribute placement.
- Remove redundant awaits from tests.
